### PR TITLE
Update polyfill for IE11 bug.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Styleguide</title>
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=String.prototype.includes,Array.prototype.find,Array.prototype.includes"></script>
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=String.prototype.includes,Array.prototype.find,Array.prototype.includes,Event"></script>
 </head>
 
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Styleguide</title>
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=String.prototype.includes,Array.prototype.find"></script>
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=String.prototype.includes,Array.prototype.find,Array.prototype.includes"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Solves [#frontend/toolbox-reader/18](https://github.com/frontend/toolbox-reader/issues/18) "Add includes polyfill for IE11" 